### PR TITLE
fix: remove non-functional messaging endpoints and align with actual API

### DIFF
--- a/docs/TOOL_CATALOG.md
+++ b/docs/TOOL_CATALOG.md
@@ -495,38 +495,20 @@ Retrieve an existing quote that was created when a booking was made. This does N
 }
 ```
 
-### `lodgify_list_threads`
-
-List conversation threads with optional filtering. Useful for inbox views, triage, and audit of guest communications.
-
-**Parameters:**
-
-- `params` (optional, object): Query parameters for filtering
-  - `includeMessages` (optional, boolean): Include messages in response
-  - `includeParticipants` (optional, boolean): Include participant details
-  - `messageLimit` (optional, number): Maximum messages per thread, 1-200
-  - `since` (optional, string): ISO date-time to filter threads since
-
-**Example:**
-
-```javascript
-{
-  "params": {
-    "includeMessages": true,
-    "includeParticipants": true,
-    "messageLimit": 50,
-    "since": "2024-03-01T00:00:00Z"
-  }
-}
-```
-
 ### `lodgify_get_thread`
 
 Retrieve a messaging conversation thread including all messages, participants, and thread metadata.
 
+**IMPORTANT**: This is currently the ONLY functional messaging endpoint in the Lodgify API v2.
+
+To find thread UIDs:
+1. Get a booking using `lodgify_get_booking`
+2. Look for the `thread_uid` field in the booking data
+3. Use that UUID with this tool to retrieve the conversation
+
 **Parameters:**
 
-- `threadGuid` (required, string): Unique thread identifier (GUID) for the conversation
+- `threadGuid` (required, string): Thread UID from booking data (found in thread_uid field)
 
 **Example:**
 
@@ -536,69 +518,30 @@ Retrieve a messaging conversation thread including all messages, participants, a
 }
 ```
 
-### `lodgify_send_message`
+## Messaging Limitations
 
-Send a message to a specific conversation thread. Respects read-only mode and will be blocked when enabled.
+**IMPORTANT API LIMITATIONS:**
+The Lodgify API has significant limitations for messaging functionality:
 
-**Parameters:**
+1. **v2 API Limitations** (current implementation):
+   - Only GET /v2/messaging/{threadGuid} exists
+   - Cannot list all threads (endpoint doesn't exist)
+   - Cannot send messages (endpoint doesn't exist)
+   - Cannot mark threads as read (endpoint doesn't exist)
+   - Cannot archive threads (endpoint doesn't exist)
 
-- `threadGuid` (required, string): Thread GUID
-- `message` (required, object): Message payload
-  - `content` (required, string): Message content
-  - `attachments` (optional, array): Array of attachment objects
-    - `fileName` (required, string): File name
-    - `fileUrl` (required, string): File URL
-    - `fileType` (optional, string): File MIME type
+2. **v1 API Issues** (legacy endpoints):
+   - POST /v1/reservation/booking/{id}/messages exists but is **NON-FUNCTIONAL**
+   - POST /v1/reservation/enquiry/{id}/messages exists but is **NON-FUNCTIONAL**
+   - These endpoints return 200 OK but do NOT actually send messages
+   - This is a known issue acknowledged by Lodgify support
+   - See: https://docs.lodgify.com/discuss/6899e597bd22070fb43002df
 
-**Example:**
-
-```javascript
-{
-  "threadGuid": "550e8400-e29b-41d4-a716-446655440000",
-  "message": {
-    "content": "Thank you for your inquiry about the Ocean View Villa.",
-    "attachments": [
-      {
-        "fileName": "villa_photos.pdf",
-        "fileUrl": "https://example.com/files/villa_photos.pdf",
-        "fileType": "application/pdf"
-      }
-    ]
-  }
-}
-```
-
-### `lodgify_mark_thread_as_read`
-
-Mark a conversation thread as read to clear unread indicators. Respects read-only mode and will be blocked when enabled.
-
-**Parameters:**
-
-- `threadGuid` (required, string): Thread GUID
-
-**Example:**
-
-```javascript
-{
-  "threadGuid": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
-
-### `lodgify_archive_thread`
-
-Archive a conversation thread to remove it from active views. Respects read-only mode and will be blocked when enabled.
-
-**Parameters:**
-
-- `threadGuid` (required, string): Thread GUID
-
-**Example:**
-
-```javascript
-{
-  "threadGuid": "550e8400-e29b-41d4-a716-446655440000"
-}
-```
+**Current Workaround:**
+For guest communication, property managers must use:
+- The Lodgify web interface or mobile app
+- Email communication outside of Lodgify
+- Wait for Lodgify to fix their messaging API endpoints
 
 ## Property Discovery & Helper Tools
 

--- a/src/api/v2/messaging/client.ts
+++ b/src/api/v2/messaging/client.ts
@@ -1,6 +1,10 @@
 /**
  * Messaging API Client Module
  * Handles all messaging-related API operations
+ *
+ * IMPORTANT: As of the latest API documentation, only the GET thread endpoint
+ * is available in v2. Other messaging operations (send, mark as read, archive, list)
+ * are not currently supported by the Lodgify API v2.
  */
 
 import type { BaseApiClient } from '../../base-client.js'
@@ -9,7 +13,11 @@ import type { MessageThread, ThreadQueryParams } from './types.js'
 
 /**
  * Messaging API Client
- * Manages message threads and communication
+ * Currently only supports retrieving thread details.
+ *
+ * Note: Lodgify v1 has POST endpoints for sending messages to bookings/enquiries,
+ * but these are currently non-functional (returning 200 OK without executing).
+ * See: https://docs.lodgify.com/discuss/6899e597bd22070fb43002df
  */
 export class MessagingClient extends BaseApiModule {
   constructor(client: BaseApiClient) {
@@ -42,6 +50,9 @@ export class MessagingClient extends BaseApiModule {
   /**
    * Get a messaging thread
    * GET /v2/messaging/{threadGuid}
+   *
+   * This is the only messaging endpoint currently available in v2.
+   * Thread UIDs can be found in booking data (thread_uid field).
    */
   async getThread<T = MessageThread>(threadGuid: string, params?: ThreadQueryParams): Promise<T> {
     const sanitized = this.validateThreadGuid(threadGuid)
@@ -52,55 +63,9 @@ export class MessagingClient extends BaseApiModule {
     )
   }
 
-  /**
-   * List message threads (if API supports it)
-   * GET /v2/messaging
-   */
-  async listThreads<T = MessageThread[]>(params?: ThreadQueryParams): Promise<T> {
-    return this.request<T>('GET', '', params ? { params: params as Record<string, unknown> } : {})
-  }
-
-  /**
-   * Send a message to a thread (if API supports it)
-   * POST /v2/messaging/{threadGuid}/messages
-   */
-  async sendMessage<T = unknown>(
-    threadGuid: string,
-    message: {
-      content: string
-      attachments?: Array<{
-        fileName: string
-        fileUrl: string
-        fileType?: string
-      }>
-    },
-  ): Promise<T> {
-    const sanitized = this.validateThreadGuid(threadGuid)
-
-    if (!message || !message.content) {
-      throw new Error('Message content is required')
-    }
-
-    return this.request<T>('POST', `${sanitized}/messages`, {
-      body: message,
-    })
-  }
-
-  /**
-   * Mark a thread as read (if API supports it)
-   * PUT /v2/messaging/{threadGuid}/read
-   */
-  async markThreadAsRead<T = unknown>(threadGuid: string): Promise<T> {
-    const sanitized = this.validateThreadGuid(threadGuid)
-    return this.request<T>('PUT', `${sanitized}/read`)
-  }
-
-  /**
-   * Archive a thread (if API supports it)
-   * PUT /v2/messaging/{threadGuid}/archive
-   */
-  async archiveThread<T = unknown>(threadGuid: string): Promise<T> {
-    const sanitized = this.validateThreadGuid(threadGuid)
-    return this.request<T>('PUT', `${sanitized}/archive`)
-  }
+  // Note: The following methods have been removed as they don't exist in the Lodgify API v2:
+  // - listThreads() - GET /v2/messaging endpoint doesn't exist
+  // - sendMessage() - POST /v2/messaging/{threadGuid}/messages endpoint doesn't exist
+  // - markThreadAsRead() - PUT /v2/messaging/{threadGuid}/read endpoint doesn't exist
+  // - archiveThread() - PUT /v2/messaging/{threadGuid}/archive endpoint doesn't exist
 }

--- a/src/lodgify-orchestrator.ts
+++ b/src/lodgify-orchestrator.ts
@@ -872,34 +872,9 @@ export class LodgifyOrchestrator {
   }
 
   // Messaging backward compatibility
+  // Messaging - Only GET thread endpoint exists and works in v2
   async getThread(threadGuid: string): Promise<MessageThread> {
     return this.messaging.getThread(threadGuid)
-  }
-
-  // Messaging
-  async listThreads(params?: Record<string, unknown>): Promise<MessageThread[]> {
-    return this.messaging.listThreads<MessageThread[]>(params)
-  }
-
-  async sendMessage(
-    threadGuid: string,
-    message: {
-      content: string
-      attachments?: Array<{ fileName: string; fileUrl: string; fileType?: string }>
-    },
-  ): Promise<unknown> {
-    this.checkReadOnly('Send Message', `/v2/messaging/${threadGuid}/messages`)
-    return this.messaging.sendMessage(threadGuid, message)
-  }
-
-  async markThreadAsRead(threadGuid: string): Promise<unknown> {
-    this.checkReadOnly('Mark Thread As Read', `/v2/messaging/${threadGuid}/read`)
-    return this.messaging.markThreadAsRead(threadGuid)
-  }
-
-  async archiveThread(threadGuid: string): Promise<unknown> {
-    this.checkReadOnly('Archive Thread', `/v2/messaging/${threadGuid}/archive`)
-    return this.messaging.archiveThread(threadGuid)
   }
 
   // Webhooks backward compatibility


### PR DESCRIPTION
## Summary
Remove messaging tools and endpoints that don't exist in Lodgify API v2, keeping only the functional GET thread endpoint.

## Problem
The messaging implementation included endpoints that either:
- Don't exist in Lodgify API v2 (list, send, mark read, archive)  
- Exist in v1 but are non-functional (return 200 OK but don't send messages)

This caused confusion and failed API calls for users trying to send messages.

## Solution
- ✅ Remove non-existent v2 messaging endpoints from `MessagingClient`
- ✅ Clean up `messaging-tools.ts` to only include working `lodgify_get_thread` tool
- ✅ Remove broken v1 messaging endpoints entirely 
- ✅ Update `TOOL_CATALOG.md` with accurate API limitations and workarounds
- ✅ Add comprehensive documentation about messaging limitations

## API Reality Check
**What Works:**
- Only `GET /v2/messaging/{threadGuid}` exists and works
- Can retrieve conversation threads using thread UID from booking data

**What Doesn't Work:**
- Cannot list all threads (endpoint doesn't exist)
- Cannot send messages (endpoints don't exist in v2)  
- Cannot mark threads as read (endpoint doesn't exist)
- Cannot archive threads (endpoint doesn't exist)
- v1 POST endpoints exist but are non-functional (known Lodgify issue)

**Workaround:**
Property managers must use Lodgify web interface or external email for guest communication.

## Testing
- ✅ All builds pass without errors
- ✅ Only functional messaging tool remains available
- ✅ Removed tools properly return "not found" errors
- ✅ 324 tests passing
- ✅ Type safety maintained

## Changes
**Modified Files:**
- `src/api/v2/messaging/client.ts` - Remove broken methods, add docs
- `src/mcp/tools/messaging-tools.ts` - Keep only working tool
- `src/lodgify-orchestrator.ts` - Remove v1 messaging references
- `docs/TOOL_CATALOG.md` - Update with accurate limitations

**Removed Files:**
- `src/api/v1/messaging/` - Entire directory (non-functional endpoints)

## Impact
- 🚫 Prevents failed attempts to use broken messaging endpoints
- ✅ Eliminates user confusion about messaging capabilities  
- 📚 Provides clear documentation about API limitations
- 🔧 Suggests proper workarounds for guest communication

@codex Please review the messaging endpoint cleanup and API alignment.

🤖 Generated with [Claude Code](https://claude.ai/code)