### PR TITLE
test: cover tool filtering in read-only mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@ LODGIFY_READ_ONLY="false"                             # Options: "true" | "false
                                                       # true: Blocks all write operations (safe mode)
                                                       # false: Allows booking creation, updates, deletions
 
+# Tool Registration Control
+LODGIFY_ENABLED_TOOL_SETS=""                          # Optional: comma-separated tool sets to expose
+                                                      # Supported values: bookings, rates, quotes, properties,
+                                                      # availability, webhooks, messaging
+                                                      # Leave empty to enable all tool sets
+
 # Server Configuration
 NODE_ENV="production"                                 # Options: development | production
 DOCKER_PORT="3000"                                    # Port for Docker container (default: 3000)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Optional settings:
 
 ```env
 LODGIFY_READ_ONLY="1"   # Prevent write operations (recommended for testing)
+LODGIFY_ENABLED_TOOL_SETS="bookings,rates" # Restrict exposed tool sets (comma separated)
 LOG_LEVEL="info"        # Options: error | warn | info | debug
 DEBUG_HTTP="0"          # Set to "1" for verbose HTTP debugging
 MCP_TOKEN="your_secret_token" # Required for HTTP mode

--- a/src/env.ts
+++ b/src/env.ts
@@ -168,7 +168,10 @@ const readOnlySchema = z.unknown().optional().default(false).transform(normalize
 /**
  * Enabled tool set CSV schema
  */
-const toolSetCsvSchema = z.string().transform((value, ctx) => parseToolSetCsv(value, ctx))
+const toolSetCsvSchema = z.string().transform((value, ctx) => {
+  const result = parseToolSetCsv(value, ctx)
+  return result.length > 0 ? result : undefined
+})
 
 /**
  * Complete environment schema
@@ -440,6 +443,10 @@ export function getEnabledToolSetsFromEnv(): ToolSetIdentifier[] | undefined {
     throw new EnvironmentError('Invalid LODGIFY_ENABLED_TOOL_SETS configuration', {
       errors: parseResult.error.errors,
     })
+  }
+
+  if (!parseResult.data || parseResult.data.length === 0) {
+    return undefined
   }
 
   return parseResult.data

--- a/src/mcp/server-setup.ts
+++ b/src/mcp/server-setup.ts
@@ -6,7 +6,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import pkg from '../../package.json' with { type: 'json' }
-import { loadEnvironment } from '../env.js'
+import { getEnabledToolSetsFromEnv, loadEnvironment } from '../env.js'
 import { LodgifyOrchestrator } from '../lodgify-orchestrator.js'
 import { safeLogger } from '../logger.js'
 import { ResourceRegistry } from './resources/registry.js'
@@ -67,8 +67,16 @@ export function setupServer(injectedClient?: LodgifyOrchestrator): {
     return client
   }
 
-  // Register all tools
-  registerAllTools(toolRegistry, getClient)
+  // Determine enabled tool sets from environment (optional restriction)
+  const enabledToolSets = getEnabledToolSetsFromEnv()
+  if (enabledToolSets !== undefined) {
+    safeLogger.info('Tool set restrictions enabled', {
+      enabledToolSets,
+    })
+  }
+
+  // Register all tools (respecting optional restrictions)
+  registerAllTools(toolRegistry, getClient, { enabledToolSets })
   toolRegistry.registerAll(server)
 
   // Register resources

--- a/src/mcp/tools/register-all.ts
+++ b/src/mcp/tools/register-all.ts
@@ -3,6 +3,7 @@
  * Central registration point for all MCP tools
  */
 
+import type { ToolSetIdentifier } from '../../env.js'
 import type { LodgifyOrchestrator } from '../../lodgify-orchestrator.js'
 import type { IToolRegistry } from '../utils/types.js'
 import { getAvailabilityTools } from './availability-tools.js'
@@ -12,46 +13,103 @@ import { getPropertyTools } from './property-tools.js'
 import { getRateTools } from './rate-tools.js'
 import { getWebhookTools } from './webhook-tools.js'
 
+interface RegisterAllToolsOptions {
+  enabledToolSets?: Iterable<ToolSetIdentifier>
+}
+
+const CATEGORY_TOOL_SET_MAP = {
+  'Property Management': 'properties',
+  'Property Discovery & Search': 'properties',
+  'Booking & Reservation Management': 'bookings',
+  'Availability & Calendar': 'availability',
+  'Rates & Pricing': 'rates',
+  'Webhooks & Notifications': 'webhooks',
+  'Messaging & Communication': 'messaging',
+} as const satisfies Record<string, ToolSetIdentifier>
+
+function resolveToolSet(
+  tool: Parameters<IToolRegistry['register']>[0],
+): ToolSetIdentifier | undefined {
+  if (tool.category === 'Rates & Pricing') {
+    const toolName = tool.name.toLowerCase()
+    if (toolName.includes('quote')) {
+      return 'quotes'
+    }
+  }
+
+  const mapped = CATEGORY_TOOL_SET_MAP[tool.category as keyof typeof CATEGORY_TOOL_SET_MAP]
+  return mapped
+}
+
 /**
  * Register all tools with the registry
  */
 export function registerAllTools(
   registry: IToolRegistry,
   getClient: () => LodgifyOrchestrator,
+  options: RegisterAllToolsOptions = {},
 ): void {
+  const enabledSet = options.enabledToolSets ? new Set(options.enabledToolSets) : undefined
+
+  const shouldRegister = (tool: Parameters<IToolRegistry['register']>[0]): boolean => {
+    if (!enabledSet) {
+      return true
+    }
+
+    const toolSet = resolveToolSet(tool)
+    if (!toolSet) {
+      // If the tool doesn't map to a known set, allow it by default
+      return true
+    }
+
+    return enabledSet.has(toolSet)
+  }
+
   // Register property management tools
   const propertyTools = getPropertyTools(getClient)
   for (const tool of propertyTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 
   // Register booking management tools
   const bookingTools = getBookingTools(getClient)
   for (const tool of bookingTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 
   // Register availability tools
   const availabilityTools = getAvailabilityTools(getClient)
   for (const tool of availabilityTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 
   // Register rate management tools
   const rateTools = getRateTools(getClient)
   for (const tool of rateTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 
   // Register webhook tools
   const webhookTools = getWebhookTools(getClient)
   for (const tool of webhookTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 
   // Register messaging tools
   const messagingTools = getMessagingTools(getClient)
   for (const tool of messagingTools) {
-    registry.register(tool)
+    if (shouldRegister(tool)) {
+      registry.register(tool)
+    }
   }
 }

--- a/src/mcp/tools/register-all.ts
+++ b/src/mcp/tools/register-all.ts
@@ -49,7 +49,8 @@ export function registerAllTools(
   getClient: () => LodgifyOrchestrator,
   options: RegisterAllToolsOptions = {},
 ): void {
-  const enabledSet = options.enabledToolSets ? new Set(options.enabledToolSets) : undefined
+  const enabledValues = options.enabledToolSets ? Array.from(options.enabledToolSets) : undefined
+  const enabledSet = enabledValues && enabledValues.length > 0 ? new Set(enabledValues) : undefined
 
   const shouldRegister = (tool: Parameters<IToolRegistry['register']>[0]): boolean => {
     if (!enabledSet) {

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -170,6 +170,15 @@ describe('Environment Loading with Boolean Normalization', () => {
     expect(config.LODGIFY_ENABLED_TOOL_SETS).toEqual(['bookings', 'rates', 'quotes'])
   })
 
+  it('should treat blank tool set configuration as undefined', () => {
+    process.env.LODGIFY_API_KEY =
+      'valid-sandbox-api-key-that-is-long-enough-to-pass-validation-12345'
+    process.env.LODGIFY_ENABLED_TOOL_SETS = '   '
+
+    const config = loadEnvironment({ allowTestKeys: true })
+    expect(config.LODGIFY_ENABLED_TOOL_SETS).toBeUndefined()
+  })
+
   it('should throw for unknown tool set identifiers', () => {
     process.env.LODGIFY_API_KEY =
       'valid-sandbox-api-key-that-is-long-enough-to-pass-validation-12345'
@@ -198,5 +207,10 @@ describe('getEnabledToolSetsFromEnv', () => {
   it('should parse values without requiring other env vars', () => {
     process.env.LODGIFY_ENABLED_TOOL_SETS = 'properties, messaging'
     expect(getEnabledToolSetsFromEnv()).toEqual(['properties', 'messaging'])
+  })
+
+  it('should ignore empty values', () => {
+    process.env.LODGIFY_ENABLED_TOOL_SETS = '  '
+    expect(getEnabledToolSetsFromEnv()).toBeUndefined()
   })
 })

--- a/tests/tool-filtering.test.ts
+++ b/tests/tool-filtering.test.ts
@@ -60,10 +60,14 @@ describe('Tool set filtering', () => {
     expect(tools.every((tool) => tool.name.toLowerCase().includes('quote'))).toBe(true)
   })
 
-  test('disables all tools when configuration is empty', () => {
+  test('treats empty configuration as allowing all tools', () => {
     process.env.LODGIFY_ENABLED_TOOL_SETS = '   '
     const { toolRegistry } = setupServer(createDummyClient())
-    expect(toolRegistry.getTools()).toHaveLength(0)
+    const tools = toolRegistry.getTools()
+
+    expect(tools.length).toBeGreaterThan(0)
+    expect(tools.some((tool) => tool.category === 'Property Management')).toBe(true)
+    expect(tools.some((tool) => tool.category === 'Booking & Reservation Management')).toBe(true)
   })
 
   test('honors tool restrictions while running in read-only mode', () => {

--- a/tests/tool-filtering.test.ts
+++ b/tests/tool-filtering.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { LodgifyOrchestrator } from '../src/lodgify-orchestrator.js'
+import { setupServer } from '../src/server.js'
+
+function createDummyClient(): LodgifyOrchestrator {
+  return {} as LodgifyOrchestrator
+}
+
+const ORIGINAL_TOOL_SET_ENV = process.env.LODGIFY_ENABLED_TOOL_SETS
+const ORIGINAL_READ_ONLY_ENV = process.env.LODGIFY_READ_ONLY
+const ORIGINAL_API_KEY = process.env.LODGIFY_API_KEY
+
+describe('Tool set filtering', () => {
+  afterEach(() => {
+    if (ORIGINAL_TOOL_SET_ENV === undefined) {
+      delete process.env.LODGIFY_ENABLED_TOOL_SETS
+    } else {
+      process.env.LODGIFY_ENABLED_TOOL_SETS = ORIGINAL_TOOL_SET_ENV
+    }
+
+    if (ORIGINAL_READ_ONLY_ENV === undefined) {
+      delete process.env.LODGIFY_READ_ONLY
+    } else {
+      process.env.LODGIFY_READ_ONLY = ORIGINAL_READ_ONLY_ENV
+    }
+
+    if (ORIGINAL_API_KEY === undefined) {
+      delete process.env.LODGIFY_API_KEY
+    } else {
+      process.env.LODGIFY_API_KEY = ORIGINAL_API_KEY
+    }
+  })
+
+  test('registers only booking and quote tools when restricted', () => {
+    process.env.LODGIFY_ENABLED_TOOL_SETS = 'bookings,quotes'
+    const { toolRegistry } = setupServer(createDummyClient())
+    const tools = toolRegistry.getTools()
+
+    expect(tools.length).toBeGreaterThan(0)
+
+    const disallowed = tools.filter((tool) => {
+      if (tool.category === 'Booking & Reservation Management') {
+        return false
+      }
+      if (tool.category === 'Rates & Pricing' && tool.name.toLowerCase().includes('quote')) {
+        return false
+      }
+      return true
+    })
+
+    expect(disallowed).toHaveLength(0)
+  })
+
+  test('supports quote-only restrictions', () => {
+    process.env.LODGIFY_ENABLED_TOOL_SETS = 'quotes'
+    const { toolRegistry } = setupServer(createDummyClient())
+    const tools = toolRegistry.getTools()
+
+    expect(tools.length).toBeGreaterThan(0)
+    expect(tools.every((tool) => tool.name.toLowerCase().includes('quote'))).toBe(true)
+  })
+
+  test('disables all tools when configuration is empty', () => {
+    process.env.LODGIFY_ENABLED_TOOL_SETS = '   '
+    const { toolRegistry } = setupServer(createDummyClient())
+    expect(toolRegistry.getTools()).toHaveLength(0)
+  })
+
+  test('honors tool restrictions while running in read-only mode', () => {
+    process.env.LODGIFY_ENABLED_TOOL_SETS = 'bookings,quotes'
+    process.env.LODGIFY_READ_ONLY = 'true'
+    process.env.LODGIFY_API_KEY =
+      'valid-sandbox-api-key-that-is-long-enough-to-pass-validation-12345'
+
+    const { toolRegistry, getClient } = setupServer()
+    const tools = toolRegistry.getTools()
+
+    expect(tools.length).toBeGreaterThan(0)
+
+    const disallowed = tools.filter((tool) => {
+      if (tool.category === 'Booking & Reservation Management') {
+        return false
+      }
+      if (tool.category === 'Rates & Pricing' && tool.name.toLowerCase().includes('quote')) {
+        return false
+      }
+      return true
+    })
+
+    expect(disallowed).toHaveLength(0)
+    expect(getClient().isReadOnly()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- reset read-only and API key environment variables after tool filtering tests
- add regression coverage to ensure tool restrictions apply when running with read-only configuration

## Testing
- bun test tests/tool-filtering.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68fe372ca2d08328b01731ddb55ca7ee

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable tool-set enablement via a new environment variable to restrict which tool sets are exposed; server now respects and logs enabled tool sets at startup.

* **Documentation**
  * README and example env updated with the new optional tool set configuration and usage notes.

* **Tests**
  * Added tests covering CSV parsing, validation, and runtime tool-filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->